### PR TITLE
配送予定表: cmd_searchとto_lot_registのURL生成をadmin_url()変数に修正

### DIFF
--- a/views/delivery-graph.blade.php
+++ b/views/delivery-graph.blade.php
@@ -1,10 +1,10 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+﻿<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, user-scalable=yes">
 
 <link href="<?php echo home_url(); ?>/wp-content/plugins/stock-management/views/css/style.css" rel="stylesheet" />
 <link href="<?php echo home_url(); ?>/wp-content/plugins/stock-management/views/css/scrolltable.css" rel="stylesheet" />
-<script>var SM_FORM_PAGE = '{{$formPage}}';</script>
+<script>var SM_FORM_PAGE = '{{$formPage}}'; var SM_ADMIN_URL = '{{ admin_url() }}';</script>
 <script src="<?php echo home_url(); ?>/wp-content/plugins/stock-management/views/js/delivery-graph.js" integrity="" crossorigin=""></script>
 
 <!-- bootstrap -->

--- a/views/js/delivery-graph.js
+++ b/views/js/delivery-graph.js
@@ -1,8 +1,8 @@
-
+﻿
 
 function cmd_search() {
 	document.forms.method = 'get';
-	document.forms.action = "/wp-admin/admin.php?page=" + SM_FORM_PAGE + "&action=search"
+	document.forms.action = SM_ADMIN_URL + "admin.php?page=" + SM_FORM_PAGE + "&action=search"
 	document.forms.cmd.value = 'search';
 	document.forms.submit();
 }
@@ -192,7 +192,7 @@ function confirm_make_lot_space(sales = null, goods = null, repeat_fg = null, us
  **/
 function to_lot_regist(sales = null, goods = null) {
 	const sdt = document.getElementById('user-search-input').value; // 開始日付を付加
-	window.location = '{{ admin_url() }}admin.php?page=lot-regist&s[sdt]=' + sdt + '&sales=' + sales + '&goods=' + goods + '&action=save';
+	window.location = SM_ADMIN_URL + 'admin.php?page=lot-regist&s[sdt]=' + sdt + '&sales=' + sales + '&goods=' + goods + '&action=save';
 }
 
 var unescapeHtml = function(str) {


### PR DESCRIPTION
## 概要
配送予定表画面の cmd_search() と to_lot_regist() 関数が生成するURLが、
WordPressのサブディレクトリ構成に対応していなかった問題を修正。

## 原因
外部JSファイル (delivery-graph.js) 内で:
- cmd_search(): URLパスが /wp-admin/admin.php とハードコードされていた
- to_lot_regist(): {{ admin_url() }} がBladeテンプレートとして展開されずそのまま残っていた

## 修正内容
- delivery-graph.blade.php に SM_ADMIN_URL 変数を追加（admin_url() の値を渡す）
- cmd_search() と to_lot_regist() のURL生成を SM_ADMIN_URL 変数を使うように変更

## 影響範囲
- 配送予定表の日付検索ボタン
- ロット登録画面への遷移